### PR TITLE
build(deps): bump cyvcf2 to 0.30.28

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     scipy==1.10
     glimix_core==3.1.13
     bgen-reader==4.0.8
-    cyvcf2==0.30.18
+    cyvcf2==0.30.28
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Closes #60 by bumping `cyvcf2` to 0.30.28.