### PR TITLE
build(pypi): fix long description content type

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ author_email = zeyun_lu@dfci.harvard.edu, Nicholas.Mancuso@med.usc.edu
 license = MIT
 license_files = LICENSE.txt
 long_description = file: README.md
-long_description_content_type = text/x-rst; charset=UTF-8
+long_description_content_type = text/markdown; charset=UTF-8
 url = https://github.com/mancusolab/sushie
 # Add here related links, for example:
 project_urls =


### PR DESCRIPTION
Fix `long_description_content_type` so `twine check` passes.